### PR TITLE
ci: grant contents:write for release, upgrade action-gh-release to v2

### DIFF
--- a/.github/workflows/build-package-onMT798x.yml
+++ b/.github/workflows/build-package-onMT798x.yml
@@ -27,6 +27,9 @@ on:
           - ubuntu-22.04
           - ubuntu-24.04
 
+permissions:
+  contents: write
+
 env:
   UPLOAD_PACKAGE: true
   UPLOAD_RELEASE: true
@@ -180,7 +183,7 @@ jobs:
           echo "status=success" >> $GITHUB_OUTPUT
 
       - name: Upload firmware to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: steps.tag.outputs.status == 'success' && !cancelled()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-package-onx86.yml
+++ b/.github/workflows/build-package-onx86.yml
@@ -27,6 +27,9 @@ on:
           - ubuntu-22.04
           - ubuntu-24.04
 
+permissions:
+  contents: write
+
 env:
   UPLOAD_PACKAGE: true
   UPLOAD_RELEASE: true
@@ -180,7 +183,7 @@ jobs:
           echo "status=success" >> $GITHUB_OUTPUT
 
       - name: Upload firmware to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: steps.tag.outputs.status == 'success' && !cancelled()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release creation failed with 403 because the default GITHUB_TOKEN only has read permissions on this repo's Actions. Declare permissions: contents: write at workflow level, and bump softprops/action-gh-release v1 (deprecated Node 20) to v2.