### PR TITLE
build: force VERSION=PKG_VERSION-rPKG_RELEASE for OpenWrt 23.05 ipk (…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,11 @@ endef
 # ucode/template/themes/liquid/VERSION（模板用它做 foot 显示与 ?v= 缓存破坏）。
 include $(TOPDIR)/feeds/luci/luci.mk
 
+# OpenWrt 23.05 的 luci.mk 版本规则只取 PKG_VERSION（忽略 PKG_RELEASE），
+# 导致 GitHub Action 编译出的 ipk 没有 r 小版本（0.4 vs 0.4-r1）。
+# 用 override VERSION 强制统一为 PKG_VERSION-rPKG_RELEASE：luci.mk 的
+# VERSION:= 是普通赋值（会被 override 压住），且本值在新版 luci.mk 与
+# i18n 子包（PKG_PO_VERSION）下与默认一致，所有 OpenWrt 版本输出相同。
+override VERSION:=$(if $(PKG_RELEASE),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION))
+
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
…0.4-r1)

OpenWrt 23.05's luci.mk sets Package VERSION to bare PKG_VERSION (ignoring PKG_RELEASE), so GitHub Action ipk artifacts came out as 0.4 instead of 0.4-r1. package.mk reads the global VERSION variable (luci.mk's VERSION:= in the package define overrides plain assignments), so use override VERSION=PKG_VERSION-rPKG_RELEASE. Same value as new luci.mk and i18n PKG_PO_VERSION, so apk/ipk are consistent on every OpenWrt branch. Verified: lede (new) still builds 0.4-r1 ipk, apk 0.4-r1.