### PR TITLE
build: move override VERSION before include luci.mk — fixes 23.05 ipk…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,15 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=然后七年 <z@7ze.top>
 PKG_LICENSE:=Apache-2.0
 
+# OpenWrt 23.05 的 luci.mk 版本规则只取 PKG_VERSION（忽略 PKG_RELEASE），
+# 导致 GitHub Action 编译出的 ipk 没有 r 小版本（0.4 vs 0.4-r1）。
+# 用 override VERSION 强制统一为 PKG_VERSION-rPKG_RELEASE。注意：必须
+# 写在 include luci.mk 之前——luci.mk 末尾会立即 eval BuildPackage，
+# 其 ipk 命名/control 里的 $(VERSION) 在那一刻固化，写后面就晚了。
+# luci.mk 的 VERSION:= 是普通赋值（被 override 压住），且本值在新版
+# luci.mk 与 i18n 子包（PKG_PO_VERSION）下与默认一致，不影响 apk/新版。
+override VERSION:=$(if $(PKG_RELEASE),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION))
+
 LUCI_TITLE:=Liquid glass theme for LuCI (>= 23)
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+luci-base
@@ -32,12 +41,5 @@ endef
 # 版本迭代：改 PKG_RELEASE（r 值）时，同步更新
 # ucode/template/themes/liquid/VERSION（模板用它做 foot 显示与 ?v= 缓存破坏）。
 include $(TOPDIR)/feeds/luci/luci.mk
-
-# OpenWrt 23.05 的 luci.mk 版本规则只取 PKG_VERSION（忽略 PKG_RELEASE），
-# 导致 GitHub Action 编译出的 ipk 没有 r 小版本（0.4 vs 0.4-r1）。
-# 用 override VERSION 强制统一为 PKG_VERSION-rPKG_RELEASE：luci.mk 的
-# VERSION:= 是普通赋值（会被 override 压住），且本值在新版 luci.mk 与
-# i18n 子包（PKG_PO_VERSION）下与默认一致，所有 OpenWrt 版本输出相同。
-override VERSION:=$(if $(PKG_RELEASE),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION))
 
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
… version (0.4-r1)

Verified on a real OpenWrt 23.05 tree: putting override VERSION after include luci.mk is too late — luci.mk evals BuildPackage immediately on include, freezing $(VERSION) into the ipk filename and CONTROL at that moment (plain PKG_VERSION). Placing the override before include makes $(VERSION) resolve to PKG_VERSION-rPKG_RELEASE there, so the 23.05 ipk is now luci-theme-liquid_0.4-r1_all.ipk with Version: 0.4-r1 in CONTROL. lede (new) ipk and apk still build 0.4-r1 unchanged.