### PR TITLE
ci: cache OpenWrt tree (source + toolchain + dl) with opt-out input (…

### DIFF
--- a/.github/workflows/build-package-onMT798x.yml
+++ b/.github/workflows/build-package-onMT798x.yml
@@ -14,6 +14,11 @@ name: OpenWrt-Theme-Build-MT798x
 on:
   workflow_dispatch:
     inputs:
+      use_cache:
+        description: '使用 OpenWrt 源码/工具链缓存加速编译（默认开启；关闭则全新构建）'
+        required: false
+        default: true
+        type: boolean
       ssh:
         description: 'SSH connection to Actions'
         required: false
@@ -88,7 +93,20 @@ jobs:
           sudo -E apt -qq install $(curl -fsSL https://raw.githubusercontent.com/zouyq/openwrt-build-action/main/dep/${CHOSEN_OS}) -y
           sudo timedatectl set-timezone "$TZ"
 
+      - name: Restore OpenWrt cache
+        id: cache
+        uses: actions/cache/restore@v4
+        if: inputs.use_cache == true
+        with:
+          # 缓存整个 openwrt/（源码 + dl 下载 + staging_dir 工具链 +
+          # build_dir 中间产物），本仓库只编译当前包，工具链复用可省大量时间
+          path: openwrt
+          key: liquid-openwrt-${{ matrix.plugin.op_branch }}-${{ runner.os }}
+          restore-keys: |
+            liquid-openwrt-${{ matrix.plugin.op_branch }}-
+
       - name: Clone source code
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pwd && df -hT $PWD
           git clone ${{ matrix.plugin.op_repo }} -b ${{ matrix.plugin.op_branch }} openwrt
@@ -102,6 +120,9 @@ jobs:
       - name: Load custom configuration
         run: |
           cd openwrt
+          # 缓存命中时 .config / package 源码为上次残留，先清空再写入当前包
+          rm -f .config
+          rm -rf package/${{ matrix.plugin.name }}
           git clone ${{ matrix.plugin.repo }} package/${{ matrix.plugin.name }}
           echo CONFIG_TARGET_mediatek=y >> .config
           echo CONFIG_TARGET_mediatek_filogic=y >> .config
@@ -145,6 +166,15 @@ jobs:
           echo "=============================================================================="
           df -hT
           echo "=============================================================================="
+
+      - name: Save OpenWrt cache
+        uses: actions/cache/save@v4
+        if: inputs.use_cache == true && success() && steps.cache.outputs.cache-hit != 'true'
+        with:
+          # 首次（缓存未命中）编译成功后保存；之后命中固定 key 不再覆盖，
+          # 工具链/源码随 op_branch 固定复用
+          path: openwrt
+          key: liquid-openwrt-${{ matrix.plugin.op_branch }}-${{ runner.os }}
 
       - name: Organize files
         id: organize

--- a/.github/workflows/build-package-onx86.yml
+++ b/.github/workflows/build-package-onx86.yml
@@ -14,6 +14,11 @@ name: OpenWrt-Theme-Build-x86
 on:
   workflow_dispatch:
     inputs:
+      use_cache:
+        description: '使用 OpenWrt 源码/工具链缓存加速编译（默认开启；关闭则全新构建）'
+        required: false
+        default: true
+        type: boolean
       ssh:
         description: 'SSH connection to Actions'
         required: false
@@ -88,7 +93,20 @@ jobs:
           sudo -E apt -qq install $(curl -fsSL https://raw.githubusercontent.com/zouyq/openwrt-build-action/main/dep/${CHOSEN_OS}) -y
           sudo timedatectl set-timezone "$TZ"
 
+      - name: Restore OpenWrt cache
+        id: cache
+        uses: actions/cache/restore@v4
+        if: inputs.use_cache == true
+        with:
+          # 缓存整个 openwrt/（源码 + dl 下载 + staging_dir 工具链 +
+          # build_dir 中间产物），本仓库只编译当前包，工具链复用可省大量时间
+          path: openwrt
+          key: liquid-openwrt-${{ matrix.plugin.op_branch }}-${{ runner.os }}
+          restore-keys: |
+            liquid-openwrt-${{ matrix.plugin.op_branch }}-
+
       - name: Clone source code
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pwd && df -hT $PWD
           git clone ${{ matrix.plugin.op_repo }} -b ${{ matrix.plugin.op_branch }} openwrt
@@ -102,6 +120,9 @@ jobs:
       - name: Load custom configuration
         run: |
           cd openwrt
+          # 缓存命中时 .config / package 源码为上次残留，先清空再写入当前包
+          rm -f .config
+          rm -rf package/${{ matrix.plugin.name }}
           git clone ${{ matrix.plugin.repo }} package/${{ matrix.plugin.name }}
           echo CONFIG_TARGET_x86=y >> .config
           echo CONFIG_TARGET_x86_64=y >> .config
@@ -145,6 +166,15 @@ jobs:
           echo "=============================================================================="
           df -hT
           echo "=============================================================================="
+
+      - name: Save OpenWrt cache
+        uses: actions/cache/save@v4
+        if: inputs.use_cache == true && success() && steps.cache.outputs.cache-hit != 'true'
+        with:
+          # 首次（缓存未命中）编译成功后保存；之后命中固定 key 不再覆盖，
+          # 工具链/源码随 op_branch 固定复用
+          path: openwrt
+          key: liquid-openwrt-${{ matrix.plugin.op_branch }}-${{ runner.os }}
 
       - name: Organize files
         id: organize


### PR DESCRIPTION
…0.4-r9)

workflow_dispatch gains use_cache (boolean, default true):
- restore actions/cache/restore@v4 caches the whole openwrt/ dir (source, dl downloads, staging_dir toolchain, build_dir) keyed by op_branch+os; cache-hit skips git clone, so tools/toolchain/install and package compile become incremental (first run still full).
- save only when cache missed && success (fixed key, no overwrite churn).
- use_cache=false restores old fresh-clone behavior.
- Load custom configuration clears .config and the package dir first so cached leftovers never leak into the current build. Applied to both x86 and MT798x workflows.