### PR TITLE
fix(ci): OR-semantics cleanup for workflow runs

### DIFF
--- a/.github/workflows/build-package-onx86.yml
+++ b/.github/workflows/build-package-onx86.yml
@@ -225,15 +225,43 @@ jobs:
           files: ${{ env.PACKAGE }}/*
 
       # ── 清理：编译成功后执行 ──────────────────────────
-      # 删除超过 8 个 或 超过 180 天的 workflow run 记录
+      # 删除 workflow run 记录（OR 语义）：
+      #   - 总数超过 8 个：删除最旧的（保留最新 8 个）
+      #   - 或 超过 180 天：删除
+      # （GitRML/delete-workflow-runs 是 AND 语义 —— 只删"既超过
+      #   180天又不在最新8个内"的，无法满足"超过8个就删"，故用脚本）
       - name: Clean old workflow runs
-        uses: GitRML/delete-workflow-runs@main
         if: steps.tag.outputs.status == 'success' && !cancelled()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          retain_days: 180
-          keep_minimum_runs: 8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          repo="${{ github.repository }}"
+          now=$(date +%s)
+          curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$repo/actions/runs?per_page=100&status=completed" \
+            > /tmp/runs.json
+          total=$(jq '.workflow_runs | length' /tmp/runs.json)
+          echo "completed runs: $total"
+          # 当前 run id（跳过自己，避免删除正在运行的）
+          self="${{ github.run_id }}"
+          deleted=0
+          # jq 输出: 每个 run 的 id 和"是否该删"（索引>=8 或 年龄>180天）
+          jq -r --argjson now "$now" --arg self "$self" '
+            .workflow_runs | to_entries[] |
+            select(.value.id != ($self|tonumber)) |
+            .key as $i |
+            .value.id as $id |
+            (.value.created_at | fromdateiso8601) as $ct |
+            (($now - $ct) / 86400 > 180 or $i >= 8) as $del |
+            if $del then "\($id)" else empty end
+          ' /tmp/runs.json | while read -r rid; do
+            echo "删除 run: $rid"
+            curl -s -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$repo/actions/runs/$rid" \
+              -o /dev/null -w "%{http_code}\n"
+            deleted=$((deleted+1))
+          done
+          echo "已删除: $deleted 个 run"
 
       # 删除超过 20 个的 release（保留最新 20 个）
       - name: Clean old releases


### PR DESCRIPTION
GitRML/delete-workflow-runs uses AND semantics (only deletes runs older than retain_days AND outside the newest keep_minimum_runs), so 23 recent runs were never cleaned. Replace with a jq+curl script implementing OR: delete runs beyond the newest 8, or older than 180d.